### PR TITLE
Return lastBuildId 0 on jobs without builds

### DIFF
--- a/src/Services/Jenkins.php
+++ b/src/Services/Jenkins.php
@@ -76,10 +76,19 @@ class Jenkins
         $url .= '/lastBuild/api/json';
         $this->_httpRequest->setUrl($url);
         $this->_log->addInfo("GettingLastBuild:" . $url);
-        $rawResponse = $this->_send();
-        $jsonResponse = json_decode($rawResponse['body'], true);
+        try {
+            $rawResponse = $this->_send();
+            $jsonResponse = json_decode($rawResponse['body'], true);
+            $number = $jsonResponse['number'];
+        } catch (\Exception $e) {
+            if ($this->_httpRequest->getResponseCode() == 404) {
+                $number = 0;
+            } else {
+                throw $e;
+            }
+        }
 
-        return $jsonResponse['number'];
+        return $number;
     }
 
     public function notifyResult($job, $status)


### PR DESCRIPTION
Tira error cuando trata de obtener el lastBuildId de un Job nuevo.
Ej. lo siguiente devuelve 404 cuando el job no tiene builds.

    /job/Deploy_Staging_Test/lastBuild/api/json